### PR TITLE
Remove unused `dataset_config`

### DIFF
--- a/scripts_python/run_harness.py
+++ b/scripts_python/run_harness.py
@@ -145,8 +145,6 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    # Handle special case for "all" - load from YAML config
-    dataset_config = Path("datasets/ade-bench-core.yaml")
     dataset_path = Path("tasks")
     task_ids = args.tasks
 
@@ -178,7 +176,6 @@ if __name__ == "__main__":
         n_concurrent_trials=args.n_concurrent_trials,
         exclude_task_ids=set(args.exclude_tasks) if args.exclude_tasks else None,
         n_attempts=args.n_attempts,
-        dataset_config=dataset_config,
         create_seed=args.seed,
         disable_diffs=args.no_diffs,
         db_type=args.db,


### PR DESCRIPTION
resolves #19

### Problem

`dataset_config` was removed from `Harness` in https://github.com/thedatamates/ade-bench/commit/1541576fa59922df1119e9dac206ac24620a8341, so I got this error:

```
$ uv run scripts_python/run_harness.py --tasks analytics_engineering001 --db duckdb --project-type dbt --agent oracle

Traceback (most recent call last):
  File "/Users/dbeatty/ade-bench/scripts_python/run_harness.py", line 165, in <module>
    harness = Harness(
              ^^^^^^^^
TypeError: Harness.__init__() got an unexpected keyword argument 'dataset_config'
```

### Solution

`git grep "dataset_config" .` showed a couple places in `scripts_python/run_harness.py` so I deleted those lines.

### Testing
These commands worked for me afterwards:

```shell
uv run scripts_python/run_harness.py --tasks analytics_engineering001 --db duckdb --project-type dbt --agent oracle
uv run scripts_python/run_harness.py --tasks all --db duckdb --project-type dbt --agent oracle
```