### PR TITLE
Make "all" the default for --tasks flag

### DIFF
--- a/scripts_python/run_harness.py
+++ b/scripts_python/run_harness.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
         "-t", "--tasks",
         type=str,
         nargs="+",
-        required=True,
+        default=["all"],
         help=("Task ID(s) to run. Use 'all' to run all tasks from the YAML configuration"),
     )
 


### PR DESCRIPTION
resolves #23

### Problem

`--tasks` is a required flag, so it must be provided, even when you just want to run **all** ready tasks (i.e., `--tasks all`.

### Solution

Make `--tasks` an optional flag with `all` as the default.

Users can override this default by passing the `--tasks` flag with a list of task names.

### Consequence

Users can run all tasks simply:

```shell
ade run
```

Or opt into the ones they want:

```shell
ade run --tasks twist shout let it out
```