### PR TITLE
Fix rendering of shell commands for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ Next, you will need [Docker Compose](https://docs.docker.com/compose/install/) a
 ```shell
 uv --version
 docker compose version
-``` ```
+```
 
 Then, download the DuckDB databases from [here](https://drive.google.com/drive/folders/1CNS_8mf81to02868HA-celmcPEFu4BPE), and put them in the `/shared/databases/duckdb` directory. You can also install them with the following command:
 


### PR DESCRIPTION
Resolves https://github.com/thedatamates/ade-bench/issues/66

### Problem

This section is not rendering correctly:
https://github.com/thedatamates/ade-bench?tab=readme-ov-file#installation

<img width="500" height="543" alt="Image" src="https://github.com/user-attachments/assets/11cf330c-5365-4742-947f-b87382452564" />

### Solution

Remove the extra set of <raw>```</raw> that is causing the rendering issue.

### 🎩 

After:

<img width="550" height="568" alt="image" src="https://github.com/user-attachments/assets/cc20b538-e5c0-4cfc-a56e-9a2c5ee87915" />