### PR TITLE
Ignoring docs in git language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+shared/projects/dbt/**/docs/** linguist-vendored
+


### PR DESCRIPTION
Fixes the HTML being +90% of repo stats cause of the 6MB of docs shipped with the repo.