### PR TITLE
Publish ade-bench to pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pypi-publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b
+        with:
+          version: "latest"
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+        with:
+          packages-dir: ./dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "ade-bench"
 version = "0.1.0"
 description = "A benchmarking framework for data analyst tasks using dbt and SQL"
 readme = "README.md"
+license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.0",
@@ -42,6 +43,9 @@ dev = [
 wizard = "ade_bench.cli.wizard:main"
 ade-bench = "ade_bench.cli.ab.main:app"
 ade = "ade_bench.cli.ab.main:app"
+
+[project.urls]
+Source = "https://github.com/dbt-labs/ade-bench"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
As a dbt Labs employee, I would like to use ade-bench as a library to improve our agents internally. So, we need it published to pypi in order for us to import it into our eval suite.

I will need help from a repo admin to enable this. Specifically, we need to add the `pypi` GitHub environment to allow publishing.