### PR TITLE
Allow external agent integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ uv run scripts_python/run_harness.py --agent sage --task-ids task1 task2
 
 3. **Adding Agents**:
    - Extend `BaseAgent` class
-   - Register in `AgentFactory`
+   - Register in `NamedAgentFactory`
    - Implement `run()` method
 
 ## Git Worktrees

--- a/ade_bench/agents/__init__.py
+++ b/ade_bench/agents/__init__.py
@@ -1,4 +1,4 @@
-from ade_bench.agents.agent_factory import AgentFactory
+from ade_bench.agents.agent_factory import NamedAgentFactory
 from ade_bench.agents.agent_name import AgentName
 from ade_bench.agents.base_agent import BaseAgent
 from ade_bench.agents.sage_agent import SageAgent
@@ -6,6 +6,6 @@ from ade_bench.agents.sage_agent import SageAgent
 __all__ = [
     "BaseAgent",
     "SageAgent",
-    "AgentFactory",
+    "NamedAgentFactory",
     "AgentName",
 ]

--- a/ade_bench/agents/agent_factory.py
+++ b/ade_bench/agents/agent_factory.py
@@ -1,10 +1,10 @@
+from abc import ABC, abstractmethod
+from typing import ClassVar
+
 from ade_bench.agents.agent_name import AgentName
 from ade_bench.agents.base_agent import BaseAgent
 from ade_bench.agents.installed_agents.claude_code.claude_code_agent import (
     ClaudeCodeAgent,
-)
-from ade_bench.agents.installed_agents.openai_codex.openai_codex_agent import (
-    OpenAICodexAgent,
 )
 from ade_bench.agents.installed_agents.gemini_cli.gemini_cli_agent import (
     GeminiCLIAgent,
@@ -12,12 +12,26 @@ from ade_bench.agents.installed_agents.gemini_cli.gemini_cli_agent import (
 from ade_bench.agents.installed_agents.macro.macro_agent import (
     MacroAgent,
 )
+from ade_bench.agents.installed_agents.openai_codex.openai_codex_agent import (
+    OpenAICodexAgent,
+)
 from ade_bench.agents.none_agent import NoneAgent
 from ade_bench.agents.sage_agent import SageAgent
 
 
-class AgentFactory:
-    AGENT_NAME_TO_CLASS = {
+class AgentFactory(ABC):
+    @property
+    @abstractmethod
+    def agent_name(self) -> AgentName:
+        pass
+
+    @abstractmethod
+    def get_agent(self, **kwargs) -> BaseAgent:
+        pass
+
+
+class NamedAgentFactory(AgentFactory):
+    AGENT_NAME_TO_CLASS: ClassVar[dict[AgentName, type[BaseAgent]]] = {
         NoneAgent.NAME: NoneAgent,
         SageAgent.NAME: SageAgent,
         ClaudeCodeAgent.NAME: ClaudeCodeAgent,
@@ -26,14 +40,20 @@ class AgentFactory:
         MacroAgent.NAME: MacroAgent,
     }
 
-    @staticmethod
-    def get_agent(agent_name: AgentName, **kwargs) -> BaseAgent:
-        agent_class = AgentFactory.AGENT_NAME_TO_CLASS.get(agent_name)
+    def __init__(self, agent_name: AgentName):
+        self._agent_name = agent_name
+
+    @property
+    def agent_name(self) -> AgentName:
+        return self._agent_name
+
+    def get_agent(self, **kwargs) -> BaseAgent:
+        agent_class = self.AGENT_NAME_TO_CLASS.get(self.agent_name)
 
         if agent_class is None:
             raise ValueError(
-                f"Unknown agent: {agent_name}. "
-                f"Available agents: {AgentFactory.AGENT_NAME_TO_CLASS.keys()}"
+                f"Unknown agent: {self.agent_name}. "
+                f"Available agents: {self.AGENT_NAME_TO_CLASS.keys()}"
             )
 
         return agent_class(**kwargs)

--- a/ade_bench/cli/ab/interact.py
+++ b/ade_bench/cli/ab/interact.py
@@ -243,12 +243,10 @@ def interact(
 
                 # Only install for certain agents that need installation
                 if agent_name in [AgentName.CLAUDE_CODE, AgentName.MACRO]:
-                    from ade_bench.agents.agent_factory import AgentFactory
+                    from ade_bench.agents.agent_factory import NamedAgentFactory
 
                     # Create the agent instance
-                    agent_instance = AgentFactory.get_agent(
-                        agent_name=agent_name,
-                    )
+                    agent_instance = NamedAgentFactory(agent_name).get_agent()
 
                     # For installed agents, we just need to do setup steps from perform_task
                     # without actually running the agent commands
@@ -377,11 +375,11 @@ def interact(
                 )
             else:
                 # For other agents, we need to get the agent instance and run it
-                from ade_bench.agents.agent_factory import AgentFactory
+                from ade_bench.agents.agent_factory import NamedAgentFactory
                 from ade_bench.harness_models import TerminalCommand
 
                 # Create the agent instance
-                agent_instance = AgentFactory.get_agent(agent_name=agent_name)
+                agent_instance = NamedAgentFactory(agent_name=agent_name).get_agent()
 
                 # Ensure log directories exist if needed
                 if hasattr(agent_instance, "LOG_DIR") and agent_instance.LOG_DIR:
@@ -448,7 +446,8 @@ def interact(
                 "bash",
                 "-c",
                 f"tmux attach -t {session_name} || bash",
-            ]
+            ],
+            check=False,
         )
 
     finally:

--- a/ade_bench/cli/ab/main.py
+++ b/ade_bench/cli/ab/main.py
@@ -12,7 +12,7 @@ import sys
 sys.path.append(str(Path(__file__).parent.parent.parent.parent))
 
 from ade_bench import Harness
-from ade_bench.agents import AgentName
+from ade_bench.agents import AgentName, NamedAgentFactory
 from scripts_python.summarize_results import display_detailed_results
 
 from ade_bench.cli.ab import migrate, check, view, save, interact as interact_module
@@ -193,7 +193,7 @@ def run(
         dataset_path=dataset_path,
         output_path=output_path,
         run_id=run_id,
-        agent_name=agent_name,
+        agent_factory=NamedAgentFactory(agent_name),
         model_name=model_name,
         agent_kwargs=agent_kwargs,
         no_rebuild=no_rebuild,


### PR DESCRIPTION
## Summary

This PR is an effort to make ade-bench more portable by:

1. Allowing the use of external agents
2. Ability to choose the output results directory for viewing

Here is a summary of the changes:

- Refactors `AgentFactory` into an abstract base class with `NamedAgentFactory` as the concrete implementation for built-in agents. This enables external consumers to create custom agent factories that integrate their own agent implementations without modifying the ade-bench codebase.
- Changes the `Harness` class to accept an `AgentFactory` instance instead of an `AgentName`, making the harness agnostic to how agents are created. External integrations can now pass their own factory that implements `get_agent()`.
- Adds a cached `_agent` property on `Harness` to lazily instantiate the agent and derive `_agent_name` from the created agent instance.

## Test plan

- [x] `uv run ade run simple001 --db duckdb --project-type dbt --agent sage` works correctly with the updated factory pattern
- [x] Implementing a custom `AgentFactory` implementation works well. I have implemented a custom agent factory for our internal agent.
