### PR TITLE
fix(asana003): correct task_id typo

### DIFF
--- a/tasks/asana003/task.yaml
+++ b/tasks/asana003/task.yaml
@@ -1,4 +1,4 @@
-task_id: asana002
+task_id: asana003
 status: ready
 description: Update dbt project to use vars
 notes: |-


### PR DESCRIPTION
## Summary
- Fixed typo in `tasks/asana003/task.yaml` where `task_id` was incorrectly set to `asana002` instead of `asana003`

## Test plan
- [ ] Verify task runs correctly with corrected task_id

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code#cortex-code-cli)