### PR TITLE
fix(simple001/002): remove hard-coded database from test queries

### DIFF
--- a/tasks/simple001/tests/columns_in_project_snowflake.sql
+++ b/tasks/simple001/tests/columns_in_project_snowflake.sql
@@ -5,7 +5,7 @@ with matches as (
   select
     count(case when table_name = 'DIMENSION_CUSTOMER' then 1 else null end) as dimension_customer_count,
     count(case when table_name = 'STG_CUSTOMER' then 1 else null end) as stg_customer_count
-  from TEMP_ADE_SIMPLE001_DATABASE.information_schema.tables
+  from information_schema.tables
   where table_schema not in ('INFORMATION_SCHEMA')
   and table_name in ('DIMENSION_CUSTOMER','STG_CUSTOMER')
 )

--- a/tasks/simple002/tests/columns_in_project_snowflake.sql
+++ b/tasks/simple002/tests/columns_in_project_snowflake.sql
@@ -5,7 +5,7 @@ with matches as (
   select
     count(case when table_name = 'DIMENSION_CUSTOMER' then 1 else null end) as dimension_customer_count,
     count(case when table_name = 'STG_CUSTOMER' then 1 else null end) as stg_customer_count
-  from TEMP_ADE_SIMPLE001_DATABASE.information_schema.tables
+  from information_schema.tables
   where table_schema not in ('INFORMATION_SCHEMA')
   and table_name in ('DIMENSION_CUSTOMER','STG_CUSTOMER')
 )


### PR DESCRIPTION
## Summary
- Remove hard-coded `TEMP_ADE_SIMPLE001_DATABASE` from `information_schema.tables` queries in Snowflake test files
- Aligns with the pattern used in DuckDB test files

## Files changed
- `tasks/simple001/tests/columns_in_project_snowflake.sql`
- `tasks/simple002/tests/columns_in_project_snowflake.sql`

## Test plan
- [x] Verify simple001 task runs correctly on Snowflake
- [x] Verify simple002 task runs correctly on Snowflake

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code#cortex-code-cli)