### PR TITLE
fix(f1001): add schema: main to source definition in setup.sh

### DIFF
--- a/tasks/f1001/setup.sh
+++ b/tasks/f1001/setup.sh
@@ -43,6 +43,7 @@ version: 2
 
 sources:
   - name: f1_dataset
+    schema: main
     tables:
       - name: circuits
       - name: constructors


### PR DESCRIPTION
## Summary
- Add `schema: main` to the source definition in `setup.sh`
- This follows the established pattern where DuckDB projects use `schema: main`
- The migration script (`f1__duckdb_to_snowflake/migration.sh`) handles overriding to `schema: public` for Snowflake
- Without a schema defined, dbt fails to locate source tables

## Files changed
- `tasks/f1001/setup.sh`

## Test plan
- [x] Verify f1001 task runs correctly on DuckDB (7/7 tests pass)
- [x] Verify migration correctly changes schema from `main` to `public` for Snowflake

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code#cortex-code-cli)