### PR TITLE
fix(airbnb): add missing field parameter to relationship tests

### DIFF
--- a/shared/migrations/airbnb__duckdb_to_snowflake_dbtf/schema.yml
+++ b/shared/migrations/airbnb__duckdb_to_snowflake_dbtf/schema.yml
@@ -15,6 +15,8 @@ models:
           - relationships:
               arguments:
                 to: ref('dim_listings')
+                field: LISTING_ID
           - relationships:
               arguments:
                 to: ref('dim_listings_hosts')
+                field: LISTING_ID

--- a/shared/projects/dbt/airbnb/models/schema.yml
+++ b/shared/projects/dbt/airbnb/models/schema.yml
@@ -13,5 +13,7 @@ models:
           - not_null
           - relationships:
               to: ref('dim_listings')
+              field: LISTING_ID
           - relationships:
               to: ref('dim_listings_hosts')
+              field: LISTING_ID


### PR DESCRIPTION
## Summary
- Add `field: LISTING_ID` to relationship tests for `dim_listings` and `dim_listings_hosts`
- Without this parameter, dbt generates invalid SQL causing syntax errors during `dbt test`

## Files changed
- `shared/projects/dbt/airbnb/models/schema.yml`
- `shared/migrations/airbnb__duckdb_to_snowflake_dbtf/schema.yml`

## Test plan
- [ ] Verify `dbt test` runs successfully on airbnb tasks

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code#cortex-code-cli)