### PR TITLE
fix(intercom): add generate_schema_name macro to force PUBLIC schema

### DIFF
--- a/shared/projects/dbt/intercom/macros/generate_schema_name.sql
+++ b/shared/projects/dbt/intercom/macros/generate_schema_name.sql
@@ -1,0 +1,6 @@
+-- Override default schema name generation to force all models into target schema
+-- This prevents the intercom package from creating models in PUBLIC_stg_intercom
+-- and PUBLIC_intercom schemas instead of PUBLIC
+{% macro generate_schema_name(custom_schema_name, node) %}
+    {{ target.schema }}
+{% endmacro %}


### PR DESCRIPTION
## Problem

The intercom dbt package (Fivetran's intercom_source) defines custom schema names in its `dbt_project.yml`:

```yaml
models:
  intercom_source:
    +schema: stg_intercom
```

Without a `generate_schema_name` override, dbt creates staging models in `{target_schema}_stg_intercom` instead of the target schema:

**Without macro (Snowflake compilation):**
- `INTERCOM_TEST_PR107` - intercom models
- `INTERCOM_TEST_PR107_stg_intercom` - staging models

**With macro:**
- `INTERCOM_TEST_PR107` - ALL models

This is a problem because:
1. The agent's solutions reference tables in the target schema
2. Staging models won't be found in the suffixed schema
3. Tasks will fail with "table not found" errors

## Solution

Add a `generate_schema_name` macro override that forces all models into the target schema:

```sql
{% macro generate_schema_name(custom_schema_name, node) %}
    {{ target.schema }}
{% endmacro %}
```

## Why DuckDB Tests Pass

DuckDB tests pass without this macro because DuckDB handles schema differently - but this fix is specifically needed for Snowflake deployments where schema suffix behavior causes model isolation.

## Testing

Verified by compiling the intercom project for Snowflake:
- Without macro: 2 schemas created (`INTERCOM_TEST_PR107`, `INTERCOM_TEST_PR107_stg_intercom`)
- With macro: 1 schema (`INTERCOM_TEST_PR107`)