### PR TITLE
fix(asana): add column_types for solution seeds on Snowflake

### DIFF
--- a/shared/projects/dbt/asana/dbt_project.yml
+++ b/shared/projects/dbt/asana/dbt_project.yml
@@ -39,6 +39,38 @@ vars:
 
 seeds:
   +quote_columns: "{{ true if target.type == 'redshift' else false }}"
+  asana:
+    # Solution seed column types for Snowflake compatibility
+    # Snowflake infers 0/1 as NUMBER(38,0) but models output BOOLEAN/TIMESTAMP
+    solution__asana__task:
+      +column_types:
+        is_completed: boolean
+        is_liked: boolean
+        is_currently_assigned: boolean
+        has_been_assigned: boolean
+        is_subtask: boolean
+        completed_at: timestamp
+        created_at: timestamp
+        due_date: timestamp
+        modified_at: timestamp
+        start_date: timestamp
+        last_assigned_at: timestamp
+        first_assigned_at: timestamp
+        parent_due_date: timestamp
+        parent_created_at: timestamp
+    solution__asana__project:
+      +column_types:
+        is_archived: boolean
+        is_public: boolean
+        created_at: timestamp
+        due_date: timestamp
+        last_modified_at: timestamp
+    solution__asana__tag:
+      +column_types:
+        created_at: timestamp
+    solution__int_asana__task_story:
+      +column_types:
+        created_at: timestamp
   main:
     +all_varchar: true
     +column_types:


### PR DESCRIPTION
## Problem
Solution seed CSV files in asana tasks have numeric values (0/1) for columns that the dbt models output as BOOLEAN or TIMESTAMP_NTZ. Snowflake infers these as NUMBER(38,0) when loading seeds, causing type mismatch errors in equality tests:

```
SQL compilation error:
    inconsistent data type for result columns for set operator input branches,
    expected TIMESTAMP_NTZ(0), got NUMBER(38,0)
    expected BOOLEAN, got NUMBER(38,0)
```

## Solution
Add explicit `+column_types` definitions in dbt_project.yml for the solution seeds:
- `solution__asana__task`: BOOLEAN columns (is_completed, is_liked, is_currently_assigned, has_been_assigned, is_subtask) and TIMESTAMP columns (completed_at, created_at, due_date, etc.)
- `solution__asana__project`: BOOLEAN columns (is_archived, is_public) and TIMESTAMP columns (created_at, due_date, last_modified_at)
- `solution__asana__tag`: TIMESTAMP column (created_at)
- `solution__int_asana__task_story`: TIMESTAMP column (created_at)

## Affected Tasks
- asana001
- asana002
- asana003
- asana004
- asana005