### PR TITLE
fix(asana): add generate_schema_name macro to force PUBLIC schema

### DIFF
--- a/shared/projects/dbt/asana/macros/generate_schema_name.sql
+++ b/shared/projects/dbt/asana/macros/generate_schema_name.sql
@@ -1,0 +1,3 @@
+{% macro generate_schema_name(custom_schema_name, node) %}
+    {{ target.schema }}
+{% endmacro %}


### PR DESCRIPTION
## Problem

The asana_source Fivetran package defines custom schema names:

```yaml
models:
  asana_source:
    +schema: stg_asana
```

Without a `generate_schema_name` override, dbt creates staging models in `{target_schema}_stg_asana` instead of the target schema on Snowflake.

## Solution

Add a `generate_schema_name` macro override that forces all models into the target schema:

```sql
{% macro generate_schema_name(custom_schema_name, node) %}
    {{ target.schema }}
{% endmacro %}
```

Same pattern as PR #107 for intercom.