### PR TITLE
fix(quickbooks): add generate_schema_name macro to force PUBLIC schema

### DIFF
--- a/shared/projects/dbt/quickbooks/macros/generate_schema_name.sql
+++ b/shared/projects/dbt/quickbooks/macros/generate_schema_name.sql
@@ -1,0 +1,3 @@
+{% macro generate_schema_name(custom_schema_name, node) %}
+    {{ target.schema }}
+{% endmacro %}


### PR DESCRIPTION
## Problem

The quickbooks_source Fivetran package defines custom schema names:

```yaml
models:
  quickbooks_source:
    +schema: quickbooks_staging
```

Without a `generate_schema_name` override, dbt creates staging models in `{target_schema}_quickbooks_staging` instead of the target schema on Snowflake.

## Solution

Add a `generate_schema_name` macro override that forces all models into the target schema:

```sql
{% macro generate_schema_name(custom_schema_name, node) %}
    {{ target.schema }}
{% endmacro %}
```

Same pattern as PR #107 (intercom) and #109 (asana).