### PR TITLE
Add --output-path parameter to view command

### DIFF
--- a/ade_bench/cli/ab/view.py
+++ b/ade_bench/cli/ab/view.py
@@ -1,14 +1,17 @@
 """Commands for viewing ADE-bench results."""
 
 import sys
-import typer
 from pathlib import Path
+from typing import Annotated
+
+import typer
 
 # Add project root to path for imports
 sys.path.append(str(Path(__file__).parent.parent.parent.parent))
 
 from ade_bench.cli.ab import runs as runs_module
 from ade_bench.cli.ab import tasks as tasks_module
+from scripts_python.view_results import main as view_results_main
 
 app = typer.Typer(
     help="View ADE-bench results",
@@ -18,13 +21,21 @@ app = typer.Typer(
 
 
 @app.callback()
-def view_callback(ctx: typer.Context):
+def view_callback(
+    ctx: typer.Context,
+    output_path: Annotated[
+        Path,
+        typer.Option(
+            "--output-path",
+            "-o",
+            help="Path to the output directory",
+        ),
+    ] = Path("experiments"),
+):
     """View ADE-bench results."""
     # If no subcommand, use the existing view_results logic
     if ctx.invoked_subcommand is None:
-        from scripts_python.view_results import main as view_results_main
-
-        view_results_main()
+        view_results_main(output_path=output_path)
 
 
 # Register runs subcommands directly under view

--- a/scripts_python/utils.py
+++ b/scripts_python/utils.py
@@ -6,9 +6,10 @@ import os
 from pathlib import Path
 
 
-def get_latest_experiment_with_results():
+def get_latest_experiment_with_results(experiments_dir: Path = Path("experiments")) -> Path | None:
     """Find the most recent experiment directory that has results.json."""
-    experiments = glob.glob("experiments/*")
+    experiments_root = Path(experiments_dir)
+    experiments = glob.glob(str(experiments_root / "*"))
     if not experiments:
         return None
 
@@ -19,6 +20,6 @@ def get_latest_experiment_with_results():
     for exp in experiments_sorted:
         results_file = Path(exp) / "results.json"
         if results_file.exists():
-            return exp
+            return Path(exp)
 
     return None

--- a/scripts_python/view_results.py
+++ b/scripts_python/view_results.py
@@ -8,16 +8,16 @@ from pathlib import Path
 # Add the project root to the sys path
 sys.path.append(str(Path(__file__).parent.parent))
 
-from scripts_python.utils import get_latest_experiment_with_results
 from scripts_python.generate_results_html import ResultsHTMLGenerator
+from scripts_python.utils import get_latest_experiment_with_results
 
 
-def main():
+def main(output_path: Path = Path("experiments")):
     """Generate HTML dashboard for the latest experiment and open it."""
     # Get the latest experiment with results
-    experiment_dir = get_latest_experiment_with_results()
+    experiment_dir = get_latest_experiment_with_results(output_path)
     if not experiment_dir:
-        print("Error: No experiments with results found. Run some tests first.")
+        print(f"Error: No experiments with results found in {output_path}. Run some tests first.")
         sys.exit(1)
 
     print(f"Using latest experiment: {experiment_dir}")


### PR DESCRIPTION
## Summary
- Adds `--output-path` / `-o` option to `ade view` command to specify a custom experiments directory
- Updates `get_latest_experiment_with_results()` to accept a configurable path instead of hardcoding `experiments/`
- Returns `Path` instead of `str` for type consistency

Stacked on #101.

## Test plan
- [x] Verify `uv run ade view` still works with default path
- [x] Verify `uv run ade view --output-path /tmp/nonexistent` shows error message
- [x] Verify `uv run ade view --output-path ./experiments` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)