### PR TITLE
Add run-level discriminator to container names

### DIFF
--- a/ade_bench/handlers/trial_handler.py
+++ b/ade_bench/handlers/trial_handler.py
@@ -164,6 +164,7 @@ class TrialHandler:
         task_key: str = "base",
         variant_config: dict | None = None,
         agent_name = None,
+        run_discriminator: str = "",
     ):
         self.trial_name = trial_name
         self.input_path = input_path
@@ -171,6 +172,7 @@ class TrialHandler:
         self.task_key = task_key
         self.variant_config = variant_config or {}
         self.agent_name = agent_name
+        self._run_discriminator = run_discriminator
 
         self._logger = logger.getChild(__name__)
         self.task = Task.from_yaml(self._task_config_path)
@@ -216,7 +218,10 @@ class TrialHandler:
 
     @property
     def client_container_name(self) -> str:
-        return f"{self.trial_name}__client".replace(".", "-")
+        base = self.trial_name.replace(".", "-")
+        if self._run_discriminator:
+            return f"{base}__{self._run_discriminator}__client"
+        return f"{base}__client"
 
     @property
     def client_image_name(self) -> str:

--- a/ade_bench/harness.py
+++ b/ade_bench/harness.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import logging
 import shutil
 import subprocess
@@ -1182,6 +1183,7 @@ class Harness:
         Returns:
             TrialResults: The results of the trial execution
         """
+        run_discriminator = hashlib.sha256(self._run_id.encode()).hexdigest()[:6]
         trial_handler = TrialHandler(
             trial_name=trial_name,
             input_path=task_path,
@@ -1189,6 +1191,7 @@ class Harness:
             task_key=task_key,
             variant_config=config,
             agent_name=self._agent_name,
+            run_discriminator=run_discriminator,
         )
 
         try:


### PR DESCRIPTION
## Summary
- Injects a 6-char hash of `run_id` into container names so parallel benchmark runs for the same tasks get unique Docker containers
- Prevents container name collisions when multiple runs execute the same task concurrently

## Test plan
- [ ] Run two concurrent benchmark runs with overlapping tasks and verify no container name conflicts
- [ ] Verify single runs still work correctly with the discriminator in container names

🤖 Generated with [Claude Code](https://claude.com/claude-code)