### PR TITLE
Add TaskScanner for structured task metadata discovery

### DIFF
--- a/ade_bench/__init__.py
+++ b/ade_bench/__init__.py
@@ -1,3 +1,4 @@
 from ade_bench.harness import BenchmarkResults, Harness
+from ade_bench.utils.task_scanner import TaskInfo, TaskScanner
 
-__all__ = ["Harness", "BenchmarkResults"]
+__all__ = ["Harness", "BenchmarkResults", "TaskInfo", "TaskScanner"]

--- a/ade_bench/cli/ab/tasks.py
+++ b/ade_bench/cli/ab/tasks.py
@@ -1,13 +1,57 @@
 """Commands for managing ADE-bench tasks."""
 
+from __future__ import annotations
+
 import typer
-import yaml
 from pathlib import Path
 from typing import Annotated
 from rich.console import Console
 from rich.table import Table
 
+from ade_bench.utils.task_scanner import TaskInfo, TaskScanner
+
 tasks_app = typer.Typer(help="Manage ADE-bench tasks")
+
+
+def _clean_text(text: str | None) -> str:
+    """Remove line breaks and normalize whitespace for display."""
+    if not text:
+        return ""
+    cleaned = " ".join(str(text).split())
+    cleaned = "".join(char for char in cleaned if ord(char) >= 32 or char in "\t\n\r")
+    return cleaned
+
+
+def _truncate_middle(text: str | None, max_length: int) -> str:
+    """Truncate text in the middle with ellipsis to fit available space."""
+    if not text or len(text) <= max_length:
+        return text or ""
+    half_length = (max_length - 3) // 2
+    return f"{text[:half_length]}...{text[-half_length:]}"
+
+
+def _variant_field(task: TaskInfo, field: str) -> str:
+    """Extract a comma-separated unique set of a variant field."""
+    values = sorted({getattr(v, field) for v in task.variants if getattr(v, field)})
+    return ", ".join(values)
+
+
+def _build_tsv_row(task: TaskInfo, key: str, prompt_text: str) -> dict:
+    """Build a single TSV export row from a TaskInfo and prompt."""
+    return {
+        "status": task.status,
+        "task_id": task.task_id,
+        "database_types": _variant_field(task, "db_type"),
+        "project_types": _variant_field(task, "project_type"),
+        "project_name": _variant_field(task, "project_name"),
+        "database_name": _variant_field(task, "db_name"),
+        "key": key,
+        "description": _clean_text(task.description),
+        "prompt": _clean_text(prompt_text),
+        "notes": _clean_text(task.notes),
+        "difficulty": task.difficulty or "unknown",
+        "tags": ", ".join(task.tags) if task.tags else "",
+    }
 
 
 @tasks_app.command()
@@ -18,250 +62,131 @@ def list(
     copy: Annotated[bool, typer.Option(help="Copy task details as TSV to clipboard")] = False,
 ):
     """List available tasks with their details and prompts."""
-    import pandas as pd
-    import subprocess
-    import sys
-
     if not tasks_dir.exists():
         typer.echo(f"Tasks directory {tasks_dir} does not exist.")
         raise typer.Exit(code=1)
 
-    # Get all task directories, excluding .template and any hidden directories
-    tasks = [
-        d
-        for d in tasks_dir.iterdir()
-        if d.is_dir() and not d.name.startswith(".") and d.name != ".template"
-    ]
+    scanner = TaskScanner(tasks_dir)
+    scanned_tasks = scanner.scan()
 
-    if not tasks:
+    if not scanned_tasks:
         typer.echo("No tasks found.")
         raise typer.Exit(code=0)
 
-    # Create a console to get terminal width
     console = Console()
     terminal_width = console.width
+    prompt_width = max(terminal_width - 46, 40)
 
-    # Calculate available width for prompt column (subtracting fixed columns and padding)
-    # Status (6) + Task ID (30) + padding/borders (approx 10) = 46
-    prompt_width = max(terminal_width - 46, 40)  # At least 40 chars even on small terminals
-
-    # Create a table
     table = Table(title="Available ADE-bench Tasks", expand=True)
     table.add_column("Status", style="magenta", width=6)
     table.add_column("Task ID", style="cyan", no_wrap=True, width=30)
     table.add_column("Prompt", no_wrap=True)
 
-    # Prepare data for table and TSV export
-    all_task_data = []
-    unique_tags = set()
-    difficulties = set()
-    unique_task_ids = set()
+    all_task_data: list[dict] = []
+    unique_tags: set[str] = set()
+    difficulties: set[str] = set()
 
-    # Function to clean text for display and export
-    def clean_text(text):
-        if not text:
-            return ""
-        # Remove line breaks and normalize whitespace
-        cleaned = " ".join(str(text).split())
-        # Remove any control characters that might cause issues
-        cleaned = "".join(char for char in cleaned if ord(char) >= 32 or char in "\t\n\r")
-        return cleaned
+    for task in scanned_tasks:
+        difficulties.add(task.difficulty or "unknown")
+        unique_tags.update(task.tags)
 
-    # Function to truncate middle of text with ellipsis to fit available space
-    def truncate_middle(text, max_length):
-        if not text or len(text) <= max_length:
-            return text
+        if not task.prompts:
+            description = _clean_text(task.description)
+            formatted_status = (
+                f"[green]{task.status}[/green]" if task.status.lower() == "ready" else task.status
+            )
+            table.add_row(
+                formatted_status,
+                task.task_id,
+                _truncate_middle(description, prompt_width),
+            )
+            all_task_data.append(_build_tsv_row(task, "", ""))
+        else:
+            for prompt in task.prompts:
+                key = prompt.key
+                prompt_text = _clean_text(prompt.prompt)
+                is_base = key == "" or key.lower() == "base"
 
-        # Calculate how much text to show from beginning and end
-        half_length = (max_length - 3) // 2  # 3 for ellipsis
-        begin = text[:half_length]
-        end = text[-half_length:]
+                display_task_id = task.task_id if is_base else f"{task.task_id}.{key}"
 
-        return f"{begin}...{end}"
-
-    # Populate table with tasks
-    for task_path in sorted(tasks):
-        task_yaml = task_path / "task.yaml"
-        if not task_yaml.exists():
-            continue
-
-        try:
-            with open(task_yaml, "r") as f:
-                task_data = yaml.safe_load(f)
-                base_task_id = task_path.name
-                unique_task_ids.add(base_task_id)
-
-                description = clean_text(task_data.get("description", "No description"))
-                status = clean_text(task_data.get("status", "unknown"))
-                difficulty = clean_text(task_data.get("difficulty", "unknown"))
-                tags = task_data.get("tags", [])
-                tags_str = ", ".join(tags) if tags else ""
-
-                # Add to collections for summary
-                difficulties.add(difficulty)
-                for tag in tags:
-                    unique_tags.add(tag)
-
-                # Extract variant information
-                variants = task_data.get("variants", [])
-
-                # Extract all the fields needed for TSV export
-                db_types = ", ".join(
-                    sorted(set([v.get("db_type", "") for v in variants if v.get("db_type")]))
-                )
-                project_types = ", ".join(
-                    sorted(
-                        set([v.get("project_type", "") for v in variants if v.get("project_type")])
-                    )
-                )
-                project_name = ", ".join(
-                    sorted(
-                        set([v.get("project_name", "") for v in variants if v.get("project_name")])
-                    )
-                )
-                database_name = ", ".join(
-                    sorted(set([v.get("db_name", "") for v in variants if v.get("db_name")]))
-                )
-                notes = clean_text(task_data.get("notes", ""))
-
-                # Get prompts
-                prompts = task_data.get("prompts", [])
-
-                if not prompts:
-                    # Use description as prompt when no prompt is available
-                    truncated_description = truncate_middle(description, prompt_width)
-
-                    # Format status with proper color
+                if is_base:
                     formatted_status = (
-                        f"[green]{status}[/green]" if status.lower() == "ready" else status
-                    )
-
-                    table.add_row(formatted_status, base_task_id, truncated_description)
-
-                    # Store data for TSV export
-                    all_task_data.append(
-                        {
-                            "status": status,
-                            "task_id": base_task_id,
-                            "database_types": db_types,
-                            "project_types": project_types,
-                            "project_name": project_name,
-                            "database_name": database_name,
-                            "key": "",
-                            "description": description,
-                            "prompt": "",
-                            "notes": notes,
-                            "difficulty": difficulty,
-                            "tags": tags_str,
-                        }
+                        f"[green]{task.status}[/green]"
+                        if task.status.lower() == "ready"
+                        else task.status
                     )
                 else:
-                    # Create one row per prompt key
-                    for idx, prompt in enumerate(prompts):
-                        key = clean_text(prompt.get("key", ""))
-                        prompt_text = clean_text(prompt.get("prompt", ""))
+                    formatted_status = "[grey70]  \u21b3[/grey70]"
 
-                        # Truncate the prompt text with ellipsis in middle using dynamic width
-                        truncated_prompt = truncate_middle(prompt_text, prompt_width)
+                table.add_row(
+                    formatted_status,
+                    display_task_id,
+                    _truncate_middle(prompt_text, prompt_width),
+                )
+                all_task_data.append(_build_tsv_row(task, key, prompt.prompt))
 
-                        # Determine if this is the base key or a variant
-                        is_base = key == "" or key.lower() == "base"
-
-                        # Build display task_id: append key if not base
-                        if is_base:
-                            display_task_id = base_task_id
-                        else:
-                            display_task_id = f"{base_task_id}.{key}"
-
-                        # Format status: show status for base, arrow for variants
-                        if is_base:
-                            formatted_status = (
-                                f"[green]{status}[/green]" if status.lower() == "ready" else status
-                            )
-                        else:
-                            formatted_status = "[grey70]  ↳[/grey70]"
-
-                        table.add_row(formatted_status, display_task_id, truncated_prompt)
-
-                        # Store full data for TSV export
-                        all_task_data.append(
-                            {
-                                "status": status,
-                                "task_id": base_task_id,
-                                "database_types": db_types,
-                                "project_types": project_types,
-                                "project_name": project_name,
-                                "database_name": database_name,
-                                "key": key,
-                                "description": description,
-                                "prompt": prompt_text,
-                                "notes": notes,
-                                "difficulty": difficulty,
-                                "tags": tags_str,
-                            }
-                        )
-
-        except Exception:
-            # Add error row
-            table.add_row("[red]error[/red]", task_path.name, "[red]Error loading task.yaml[/red]")
-
-    # Print the table
     console.print(table)
 
-    # Print summary
     console.print("\n[bold]Summary:[/bold]")
-    console.print(f"Total tasks: {len(unique_task_ids)}")
+    console.print(f"Total tasks: {len(scanned_tasks)}")
     console.print(f"Total rows (with prompts): {len(all_task_data)}")
     console.print(f"Difficulties: {', '.join(sorted(difficulties))}")
     console.print(f"Tags: {', '.join(sorted(unique_tags))}")
 
-    # Handle clipboard copy if requested
     if copy:
-        try:
-            # Create DataFrame and TSV content
-            df = pd.DataFrame(all_task_data)
-            # Order columns like in the original extract_task_details.py script
-            column_order = [
-                "status",
-                "task_id",
-                "database_types",
-                "project_types",
-                "project_name",
-                "database_name",
-                "key",
-                "description",
-                "prompt",
-                "notes",
-                "difficulty",
-                "tags",
-            ]
-            df = df[column_order]
-            # Sort by task_id and key like extract_task_details.py
-            df = df.sort_values(["task_id", "key"])
-            tsv_content = df.to_csv(index=False, sep="\t")
-
-            # Copy to clipboard based on platform
-            copy_success = False
-            if sys.platform == "darwin":  # macOS
-                process = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE, text=True)
-                process.communicate(input=tsv_content)
-                copy_success = True
-            elif sys.platform.startswith("linux"):  # Linux
-                process = subprocess.Popen(
-                    ["xclip", "-selection", "clipboard"], stdin=subprocess.PIPE, text=True
-                )
-                process.communicate(input=tsv_content)
-                copy_success = True
-
-            if copy_success:
-                console.print("\n[green]TSV copied to clipboard[/green]")
-            else:
-                console.print("\n[yellow]Clipboard copy not supported on this platform[/yellow]")
-        except ImportError:
-            console.print(
-                "\n[red]Error: pandas required for TSV export. Install with: pip install pandas[/red]"
-            )
-        except Exception as e:
-            console.print(f"\n[red]Error copying to clipboard: {str(e)}[/red]")
+        _copy_to_clipboard(console, all_task_data)
     else:
         console.print("\n[dim]Tip: Use --copy to copy task details as TSV to clipboard[/dim]")
+
+
+def _copy_to_clipboard(console: Console, all_task_data: list[dict]) -> None:
+    """Copy task data as TSV to the system clipboard."""
+    import subprocess
+    import sys
+
+    try:
+        import pandas as pd
+    except ImportError:
+        console.print(
+            "\n[red]Error: pandas required for TSV export. Install with: pip install pandas[/red]"
+        )
+        return
+
+    try:
+        df = pd.DataFrame(all_task_data)
+        column_order = [
+            "status",
+            "task_id",
+            "database_types",
+            "project_types",
+            "project_name",
+            "database_name",
+            "key",
+            "description",
+            "prompt",
+            "notes",
+            "difficulty",
+            "tags",
+        ]
+        df = df[column_order]
+        df = df.sort_values(["task_id", "key"])
+        tsv_content = df.to_csv(index=False, sep="\t")
+
+        copy_success = False
+        if sys.platform == "darwin":
+            process = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE, text=True)
+            process.communicate(input=tsv_content)
+            copy_success = True
+        elif sys.platform.startswith("linux"):
+            process = subprocess.Popen(
+                ["xclip", "-selection", "clipboard"], stdin=subprocess.PIPE, text=True
+            )
+            process.communicate(input=tsv_content)
+            copy_success = True
+
+        if copy_success:
+            console.print("\n[green]TSV copied to clipboard[/green]")
+        else:
+            console.print("\n[yellow]Clipboard copy not supported on this platform[/yellow]")
+    except Exception as e:
+        console.print(f"\n[red]Error copying to clipboard: {str(e)}[/red]")

--- a/ade_bench/utils/task_scanner.py
+++ b/ade_bench/utils/task_scanner.py
@@ -1,0 +1,121 @@
+"""Task scanner for discovering and filtering ade-bench tasks.
+
+Provides a structured API for loading task metadata from task.yaml files,
+with optional filtering by database type, project type, status, and task IDs.
+"""
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, field_validator
+
+from ade_bench.handlers.trial_handler import TaskPrompt
+from ade_bench.harness_models import SolutionSeedConfig, VariantConfig
+from ade_bench.utils.logger import logger
+
+
+class TaskInfo(BaseModel):
+    """Structured metadata for an ade-bench task, loaded from task.yaml."""
+
+    task_id: str
+    status: str
+    description: str
+    prompts: list[TaskPrompt]
+    variants: list[VariantConfig]
+    difficulty: str | None = None
+    tags: list[str] = []
+    author_name: str | None = None
+    author_email: str | None = None
+    test_setup: str | None = None
+    notes: str | None = None
+    solution_seeds: list[SolutionSeedConfig] = []
+
+    @field_validator("solution_seeds", mode="before")
+    @classmethod
+    def _normalize_solution_seeds(cls, v: list) -> list:
+        """Normalize mixed str/dict solution_seeds from YAML into dicts."""
+        normalized = []
+        for item in v:
+            if isinstance(item, str):
+                normalized.append({"table_name": item})
+            else:
+                normalized.append(item)
+        return normalized
+
+    def has_variant(self, db_type: str, project_type: str) -> bool:
+        """Check if this task has a variant matching the given db_type and project_type."""
+        return any(v.db_type == db_type and v.project_type == project_type for v in self.variants)
+
+
+class TaskScanner:
+    """Scans an ade-bench tasks directory and returns structured task metadata."""
+
+    def __init__(self, tasks_dir: Path):
+        """Initialize the scanner.
+
+        Args:
+            tasks_dir: Path to the directory containing task subdirectories.
+        """
+        self._tasks_dir = tasks_dir
+
+    @property
+    def tasks_dir(self) -> Path:
+        """Return the tasks directory path."""
+        return self._tasks_dir
+
+    def scan(
+        self,
+        task_ids: list[str] | None = None,
+        db_type: str | None = None,
+        project_type: str | None = None,
+        status: str | None = None,
+    ) -> list[TaskInfo]:
+        """Scan task.yaml files and return matching tasks.
+
+        Args:
+            task_ids: Only include tasks whose task_id is in this list.
+            db_type: Only include tasks with a variant matching this database type.
+            project_type: Only include tasks with a variant matching this project type.
+            status: Only include tasks with this status (e.g. "ready").
+
+        Returns:
+            List of TaskInfo objects sorted by task_id.
+        """
+        tasks: list[TaskInfo] = []
+
+        for task_dir in sorted(self._tasks_dir.iterdir()):
+            if not task_dir.is_dir() or task_dir.name.startswith("."):
+                continue
+
+            task_file = task_dir / "task.yaml"
+            if not task_file.exists():
+                continue
+
+            try:
+                with open(task_file) as f:
+                    task_data = yaml.safe_load(f)
+
+                task_info = TaskInfo.model_validate(task_data)
+
+                if task_ids and task_info.task_id not in task_ids:
+                    continue
+
+                if status and task_info.status != status:
+                    continue
+
+                if db_type or project_type:
+                    has_match = any(
+                        (db_type is None or v.db_type == db_type)
+                        and (project_type is None or v.project_type == project_type)
+                        for v in task_info.variants
+                    )
+                    if not has_match:
+                        continue
+
+                tasks.append(task_info)
+            except Exception as e:
+                logger.warning(f"Failed to load task from {task_file}: {e}")
+                continue
+
+        logger.info(f"Scanned {len(tasks)} tasks from {self._tasks_dir}")
+        return tasks


### PR DESCRIPTION
# Motivation
Enable a programmatic option to understand the full set of tasks within ade-bench for reporting purposes.


**Use case:** I'm integrating reporting with external systems, in my case, LangSmith. For each task run, I need to know the name and prompt before running the full suite. This helps me set up my traces so I can attach them to experiments for reporting.


## Summary
- Adds `TaskScanner` class and `TaskInfo` Pydantic model to `ade_bench/utils/task_scanner.py` for scanning and filtering task metadata from `task.yaml` files
- Reuses existing models (`VariantConfig`, `TaskPrompt`, `SolutionSeedConfig`) instead of duplicating them
- Supports optional filtering by `task_ids`, `db_type`, `project_type`, and `status`
- Refactors `ade view tasks` CLI to use `TaskScanner` instead of inline YAML parsing (net -204/+261 lines)
- Exports `TaskScanner` and `TaskInfo` from the package so external consumers (e.g. `ai-codegen-api`) can use them directly instead of maintaining their own task scanner

## Usage
```python
from ade_bench import TaskScanner
from pathlib import Path

scanner = TaskScanner(Path("tasks"))
all_tasks = scanner.scan()
ready_duckdb = scanner.scan(status="ready", db_type="duckdb", project_type="dbt")
specific = scanner.scan(task_ids=["airbnb001", "f1001"])
```

## Test plan
- [x] `ade view tasks` output matches previous behavior
- [x] All filter combinations work (status, db_type, project_type, task_ids, combinations)
- [x] Package-level import `from ade_bench import TaskScanner, TaskInfo` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)