### PR TITLE
fix(asana003): relax check_model_sources to accept multiple source() calls

### DIFF
--- a/tasks/asana003/tests/check_model_sources.sql
+++ b/tasks/asana003/tests/check_model_sources.sql
@@ -17,7 +17,7 @@
     {% set model_refs = model_node.refs %}
     {% set model_sources = model_node.sources %}
 
-    {% if model_refs | length != 0 or model_sources | length != 1 %}
+    {% if model_refs | length != 0 or model_sources | length == 0 %}
         select '{{ model }} not updated correctly' as error_message
     {% else %}
         select 1 where false


### PR DESCRIPTION
## Summary
- Changes `model_sources | length != 1` to `model_sources | length == 0` in `tasks/asana003/tests/check_model_sources.sql`
- The `fill_staging_columns` macro uses a second `source()` call per model, making `model_sources` length == 2 for valid agent solutions
- This test is the **sole blocker** for asana003: in 34+ out of 80 runs, all 17 data tests pass but this structural check fails

## Evidence
- asana003 passes 0/7 Opus variants (never-passed task)
- 34/80 runs have ALL AUTO equality/existence tests passing, only `check_model_sources` fails
- The prompt-only validation experiment confirmed this is a test bug, not an agent bug

## Test plan
- [ ] Run `uv run ade run asana003 --db duckdb --project-type dbt --agent sage` to verify reference solution still passes
- [ ] Run with AI agent to verify real-world fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>