### PR TITLE
fix(f1001): correct error message in stg_results_uses_correct_sources

### DIFF
--- a/tasks/f1001/tests/stg_results_uses_correct_sources.sql
+++ b/tasks/f1001/tests/stg_results_uses_correct_sources.sql
@@ -4,9 +4,9 @@
 {% set node = graph.nodes["model." ~ project_name ~ "." ~ model_name ] %}
 {% set ref_list = node.refs %}
 
--- Model should have one source
+-- Model should have three references
 {% if ref_list | length != 3 %}
-    select '{{ model_name }} does not have two references' as error_message union all
+    select '{{ model_name }} does not have three references' as error_message union all
 {% elif 'src_position_descriptions' not in ref_list | map(attribute='name') | list %}
     select '{{ model_name }} does not use src_position_descriptions as source' as error_message union all
 {% elif 'src_results' not in ref_list | map(attribute='name') | list %}


### PR DESCRIPTION
## Summary
- Fixes comment and error message in `tasks/f1001/tests/stg_results_uses_correct_sources.sql`
- Comment said "one source", error said "two references" but the assertion checks for 3 refs
- Cosmetic fix only — does not change pass/fail behavior

## Test plan
- [ ] Verify error message is correct by reading the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>