### PR TITLE
fix(airbnb004): correct error message in fct_reviews_is_incremental

### DIFF
--- a/tasks/airbnb004/tests/fct_reviews_is_incremental.sql
+++ b/tasks/airbnb004/tests/fct_reviews_is_incremental.sql
@@ -3,7 +3,7 @@
 {% set mat = node.config.materialized %}
 
 {% if mat != 'incremental' %}
-    select 'Model is not a view' as error_message
+    select 'Model is not incremental' as error_message
 {% else %}
     select 1 where false
 {% endif %}


### PR DESCRIPTION
## Summary
- Fixes error message in `tasks/airbnb004/tests/fct_reviews_is_incremental.sql`
- Said "Model is not a view" but the test checks for incremental materialization
- Copy-paste error from a view test — cosmetic fix only

## Test plan
- [ ] Verify error message is correct by reading the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>