### PR TITLE
fix(quickbooks004): correct error message in check_if_models_use_xr_var

### DIFF
--- a/tasks/quickbooks004/tests/check_if_models_use_xr_var.sql
+++ b/tasks/quickbooks004/tests/check_if_models_use_xr_var.sql
@@ -32,7 +32,7 @@
     {% if "using_exchange_rate" in raw_sql %}
         select 'none' as error_message where false union all
     {% else %}
-        select 'using_department is in {{ table_name }} should not be' as error_message union all
+        select 'using_exchange_rate is not in {{ table_name }}' as error_message union all
     {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
## Summary
- Fixes error message in `tasks/quickbooks004/tests/check_if_models_use_xr_var.sql`
- Said "using_department is in" but should say "using_exchange_rate is not in"
- Both variable name (copy-paste from quickbooks002/003) and error direction were wrong
- Cosmetic fix only — does not change pass/fail behavior

## Test plan
- [ ] Verify error message is correct by reading the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>