### PR TITLE
Add release process docs and bump to 1.0.0rc1

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,27 @@
+# Releasing ade-bench
+
+## Version scheme
+
+We follow [PEP 440](https://peps.python.org/pep-0440/) versioning:
+
+- **Release candidates:** `1.0.0rc1`, `1.0.0rc2`, ...
+- **Stable releases:** `1.0.0`
+
+## How to release
+
+1. **Bump the version** in `pyproject.toml` via a PR to `main`.
+2. **Merge** the PR.
+3. **Trigger the publish workflow** from the GitHub Actions UI:
+   Actions > "Publish to PyPI" > Run workflow (from `main`).
+
+That's it. The workflow builds, tests, and publishes to PyPI.
+
+## Installing
+
+```bash
+# Stable release
+uv add ade-bench
+
+# Release candidate (pre-release)
+uv add --prerelease allow ade-bench
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ade-bench"
-version = "0.1.0"
+version = "1.0.0rc1"
 description = "A benchmarking framework for data analyst tasks using dbt and SQL"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Why
Document the release process so it's clear how to publish RC and stable versions.

## What
- Add RELEASING.md with version scheme (PEP 440), release flow, and install instructions
- Bump version from 0.1.0 to 1.0.0rc1 in pyproject.toml

## Notes
Drafted by an AI assistant under the direction of the author.