### PR TITLE
fix(f1002): Remove p1, p2, p3 from most_podiums yml spec

### DIFF
--- a/shared/projects/dbt/f1/models/stats/__stats.yml
+++ b/shared/projects/dbt/f1/models/stats/__stats.yml
@@ -122,7 +122,7 @@ models:
         description: "The number of fastest laps recorded by the driver."
 
   - name: most_podiums
-    description: "This model ranks the top 20 drivers based on the number of podium finishes achieved, including a breakdown of 1st, 2nd, and 3rd place finishes."
+    description: "This model ranks the top 20 drivers based on the number of podium finishes achieved."
 
     columns:
       - name: rank
@@ -133,15 +133,6 @@ models:
 
       - name: podiums
         description: "The number of podium finishes achieved by the driver."
-
-      - name: p1
-        description: "The number of times the driver finished in 1st place."
-
-      - name: p2
-        description: "The number of times the driver finished in 2nd place."
-
-      - name: p3
-        description: "The number of times the driver finished in 3rd place."
 
   - name: most_pole_positions
     description: "This model ranks the top 20 drivers based on the number of pole positions achieved in their Formula 1 career."


### PR DESCRIPTION
Alternate approach to #138 per @joellabes suggestion: instead of adding p1/p2/p3 to the solution SQL and seed CSV, this removes them from the __stats.yml spec to match what the shared most_podiums.sql already produces.

**Changes:**
- Removed p1, p2, p3 column definitions from the most_podiums model in __stats.yml
- Updated the model description to remove "including a breakdown of 1st, 2nd, and 3rd place finishes"

**Impact:**
- Solution SQL, seed CSV, and shared model already only have 3 columns -- no other code changes needed.
- No other f1 tasks are affected: most_podiums is only referenced in f1002.
- The finishes_by_driver model (which does have p1-p21plus) is unchanged.

**Trade-off vs #138:**
This is simpler (1 file, net -9 lines) but makes f1002 a slightly easier eval since agents no longer need to figure out the position breakdown columns.

**Test plan:**
- Verified existing solution SQL, seed CSV, and shared model already match (3 columns only)
- Verified no other f1 tasks reference most_podiums or its p1/p2/p3 columns
- Grep confirmed zero references to p1/p2/p3 in any task test SQL files