### PR TITLE
Include shared/, docker/, and tasks/ in the built wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,12 @@ Source = "https://github.com/dbt-labs/ade-bench"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["ade_bench"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"shared" = "shared"
+
 [tool.ruff]
 line-length = 100
 target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ packages = ["ade_bench"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "shared" = "shared"
+"docker" = "docker"
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ packages = ["ade_bench"]
 [tool.hatch.build.targets.wheel.force-include]
 "shared" = "shared"
 "docker" = "docker"
+"tasks" = "tasks"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
# Why

`ade_bench/handlers/trial_handler.py` resolves `shared/` as `Path(files("ade_bench")) / "../shared"` — i.e. a sibling of the installed `ade_bench` package. This works for editable installs (hatchling puts the source root on `sys.path`, so the source-tree `shared/` is reachable) but breaks for any non-editable install — git, wheel, PyPI — because hatchling's auto-discovery only ships the `ade_bench` package, not the sibling data directories.

Symptom from a non-editable install:

```
open .../site-packages/shared/defaults/docker-compose-duckdb-dbt.yaml: no such file or directory
```

Same root cause affects `docker/` (referenced by compose build contexts) and `tasks/` (consumed by ai-codegen-api's `evaluate.py` to enumerate task definitions — currently forces a full `ade-bench` checkout alongside any consumer). Bundling these makes `pip install ade-bench` self-sufficient — no sibling checkout required.

# What

Force-include `shared/`, `docker/`, and `tasks/` in the wheel alongside `ade_bench/`. Built wheel size is ~13 MB.

Verified by building the wheel and confirming `shared/defaults/docker-compose-duckdb-dbt.yaml`, `docker/base/*`, and `tasks/airbnb001/task.yaml` are present.

Drafted by Claude Opus 4.7 under the direction of @wiggzz
