### PR TITLE
DI-4253: support OPENAI_CODEX_REASONING_EFFORT env var

### DIFF
--- a/ade_bench/agents/installed_agents/openai_codex/openai_codex_agent.py
+++ b/ade_bench/agents/installed_agents/openai_codex/openai_codex_agent.py
@@ -17,8 +17,8 @@ class OpenAICodexAgent(AbstractInstalledAgent):
     # Codex doesn't seem to have an allowed tools option, but I didn't fully check.
     # ALLOWED_TOOLS = ["Bash", "Edit", "Write", "NotebookEdit", "WebFetch"]
 
-    # gpt-5 family default; lowering matches what the dbt Cloud studio dev
-    # agent uses by default so eval comparisons aren't confounded by effort.
+    # Optional env-var override for codex's reasoning effort, useful when
+    # comparing codex against another agent at a matched effort level.
     _REASONING_EFFORT_ENV_VAR = "OPENAI_CODEX_REASONING_EFFORT"
 
     def __init__(self, **kwargs):

--- a/ade_bench/agents/installed_agents/openai_codex/openai_codex_agent.py
+++ b/ade_bench/agents/installed_agents/openai_codex/openai_codex_agent.py
@@ -17,6 +17,10 @@ class OpenAICodexAgent(AbstractInstalledAgent):
     # Codex doesn't seem to have an allowed tools option, but I didn't fully check.
     # ALLOWED_TOOLS = ["Bash", "Edit", "Write", "NotebookEdit", "WebFetch"]
 
+    # gpt-5 family default; lowering matches what the dbt Cloud studio dev
+    # agent uses by default so eval comparisons aren't confounded by effort.
+    _REASONING_EFFORT_ENV_VAR = "OPENAI_CODEX_REASONING_EFFORT"
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._codex_parser = CodexParser()
@@ -39,10 +43,17 @@ class OpenAICodexAgent(AbstractInstalledAgent):
         else:
             model_command = ""
 
+        # Optional override of codex's default reasoning effort. Set via env var
+        # rather than a constructor kwarg so the existing harness/factory plumbing
+        # doesn't need to change to thread it through.
+        effort_command = ""
+        if effort := os.environ.get(self._REASONING_EFFORT_ENV_VAR):
+            effort_command = f" -c {shlex.quote(f'model_reasoning_effort={effort}')}"
+
         command = (
             f"echo 'AGENT RESPONSE: ' && "
             f"printenv OPENAI_API_KEY | codex login --with-api-key && "
-            f"codex --ask-for-approval never {model_command} "
+            f"codex --ask-for-approval never{model_command}{effort_command} "
             f"exec "
             f"--json --sandbox danger-full-access --skip-git-repo-check "
             f"{escaped_prompt}"

--- a/tests/agents/installed_agents/test_openai_codex_agent.py
+++ b/tests/agents/installed_agents/test_openai_codex_agent.py
@@ -1,0 +1,37 @@
+from unittest.mock import patch
+
+from ade_bench.agents.installed_agents.openai_codex.openai_codex_agent import (
+    OpenAICodexAgent,
+)
+
+
+class TestReasoningEffortEnvVar:
+    def test_no_env_var_omits_flag(self):
+        """When OPENAI_CODEX_REASONING_EFFORT is unset, no -c flag is emitted."""
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "key"}, clear=False):
+            agent = OpenAICodexAgent()
+            commands = agent._run_agent_commands("do the thing")
+        assert "model_reasoning_effort" not in commands[0].command
+
+    def test_env_var_emits_config_flag(self):
+        """When set, the value is passed via -c model_reasoning_effort=<value>."""
+        env = {"OPENAI_API_KEY": "key", "OPENAI_CODEX_REASONING_EFFORT": "low"}
+        with patch.dict("os.environ", env, clear=False):
+            agent = OpenAICodexAgent()
+            commands = agent._run_agent_commands("do the thing")
+        assert "-c model_reasoning_effort=low" in commands[0].command
+
+    def test_env_var_value_is_shell_quoted(self):
+        """Value goes through shlex.quote so injection attempts are inert."""
+        env = {
+            "OPENAI_API_KEY": "key",
+            "OPENAI_CODEX_REASONING_EFFORT": "low; rm -rf /",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            agent = OpenAICodexAgent()
+            commands = agent._run_agent_commands("do the thing")
+        # The whole key=value pair is one shell-quoted token, so `rm -rf /` is
+        # part of the quoted argument — never a second command.
+        assert "rm -rf /" not in commands[0].command.replace(
+            "'model_reasoning_effort=low; rm -rf /'", ""
+        )


### PR DESCRIPTION
## Why

When comparing the codex baseline against another agent, it's useful to be able to dial codex's reasoning effort to match the other agent's configuration, so the comparison isn't confounded by effort defaults. There's no way to do that today from outside the agent.

## What

`OpenAICodexAgent` reads an optional `OPENAI_CODEX_REASONING_EFFORT` env var and, if set, passes it through as `-c model_reasoning_effort=<value>` on the codex command line. When unset, the command is unchanged.

Going through an env var rather than a constructor kwarg avoids touching the `Harness` / `AgentFactory` plumbing, since callers (`run_harness.py`, downstream wrappers) don't currently thread arbitrary agent kwargs through.

Drafted by Opus 4.7 under the direction of @wiggzz.
