### PR TITLE
Disable dbt-fusion + duckdb variant on 6 analytics_engineering tasks

### DIFF
--- a/tasks/analytics_engineering001/task.yaml
+++ b/tasks/analytics_engineering001/task.yaml
@@ -30,7 +30,9 @@ variants:
   project_type: dbt-fusion
   project_name: analytics_engineering
   migration_directory: analytics_engineering__duckdb_to_snowflake
-- db_type: duckdb
-  db_name: analytics_engineering
-  project_type: dbt-fusion
-  project_name: analytics_engineering
+# Disabled: dbt-fusion + duckdb fails to build fact_inventory due to
+# https://github.com/dbt-labs/dbt-fusion/issues/2226 (STRPTIME->DATE cast + window function)
+#- db_type: duckdb
+#  db_name: analytics_engineering
+#  project_type: dbt-fusion
+#  project_name: analytics_engineering

--- a/tasks/analytics_engineering002/task.yaml
+++ b/tasks/analytics_engineering002/task.yaml
@@ -42,7 +42,9 @@ variants:
   project_type: dbt-fusion
   project_name: analytics_engineering
   migration_directory: analytics_engineering__duckdb_to_snowflake
-- db_type: duckdb
-  db_name: analytics_engineering
-  project_type: dbt-fusion
-  project_name: analytics_engineering
+# Disabled: dbt-fusion + duckdb fails to build fact_inventory due to
+# https://github.com/dbt-labs/dbt-fusion/issues/2226 (STRPTIME->DATE cast + window function)
+#- db_type: duckdb
+#  db_name: analytics_engineering
+#  project_type: dbt-fusion
+#  project_name: analytics_engineering

--- a/tasks/analytics_engineering004/task.yaml
+++ b/tasks/analytics_engineering004/task.yaml
@@ -38,7 +38,9 @@ variants:
   project_type: dbt-fusion
   project_name: analytics_engineering
   migration_directory: analytics_engineering__duckdb_to_snowflake
-- db_type: duckdb
-  db_name: analytics_engineering
-  project_type: dbt-fusion
-  project_name: analytics_engineering
+# Disabled: dbt-fusion + duckdb fails to build fact_inventory due to
+# https://github.com/dbt-labs/dbt-fusion/issues/2226 (STRPTIME->DATE cast + window function)
+#- db_type: duckdb
+#  db_name: analytics_engineering
+#  project_type: dbt-fusion
+#  project_name: analytics_engineering

--- a/tasks/analytics_engineering005/task.yaml
+++ b/tasks/analytics_engineering005/task.yaml
@@ -41,7 +41,9 @@ variants:
   project_type: dbt-fusion
   project_name: analytics_engineering
   migration_directory: analytics_engineering__duckdb_to_snowflake
-- db_type: duckdb
-  db_name: analytics_engineering
-  project_type: dbt-fusion
-  project_name: analytics_engineering
+# Disabled: dbt-fusion + duckdb fails to build fact_inventory due to
+# https://github.com/dbt-labs/dbt-fusion/issues/2226 (STRPTIME->DATE cast + window function)
+#- db_type: duckdb
+#  db_name: analytics_engineering
+#  project_type: dbt-fusion
+#  project_name: analytics_engineering

--- a/tasks/analytics_engineering006/task.yaml
+++ b/tasks/analytics_engineering006/task.yaml
@@ -40,7 +40,9 @@ variants:
   project_type: dbt-fusion
   project_name: analytics_engineering
   migration_directory: analytics_engineering__duckdb_to_snowflake
-- db_type: duckdb
-  db_name: analytics_engineering
-  project_type: dbt-fusion
-  project_name: analytics_engineering
+# Disabled: dbt-fusion + duckdb fails to build fact_inventory due to
+# https://github.com/dbt-labs/dbt-fusion/issues/2226 (STRPTIME->DATE cast + window function)
+#- db_type: duckdb
+#  db_name: analytics_engineering
+#  project_type: dbt-fusion
+#  project_name: analytics_engineering

--- a/tasks/analytics_engineering007/task.yaml
+++ b/tasks/analytics_engineering007/task.yaml
@@ -48,7 +48,9 @@ variants:
   project_type: dbt-fusion
   project_name: analytics_engineering
   migration_directory: analytics_engineering__duckdb_to_snowflake
-- db_type: duckdb
-  db_name: analytics_engineering
-  project_type: dbt-fusion
-  project_name: analytics_engineering
+# Disabled: dbt-fusion + duckdb fails to build fact_inventory due to
+# https://github.com/dbt-labs/dbt-fusion/issues/2226 (STRPTIME->DATE cast + window function)
+#- db_type: duckdb
+#  db_name: analytics_engineering
+#  project_type: dbt-fusion
+#  project_name: analytics_engineering


### PR DESCRIPTION
## Summary

- 8 tasks were failing the `dbt-fusion / Sage agent always passes` CI job on `main` — all rooted in `fact_inventory` failing to build under dbt-fusion + duckdb (the `Sage agent always passes` job for the regular `dbt` project_type was unaffected)
- Bug repro and full diagnosis tracked upstream: dbt-labs/dbt-core#15112
- Comment out the `dbt-fusion + duckdb` variant on the 6 affected `analytics_engineering` task.yamls. Snowflake + dbt-fusion variants are left intact (this is a duckdb-driver-specific bug).

Affected tasks (whose `dbt-fusion + duckdb` variant is now skipped):
- \`analytics_engineering001\`
- \`analytics_engineering002\` (base + medium prompts)
- \`analytics_engineering004\`
- \`analytics_engineering005\`
- \`analytics_engineering006\`
- \`analytics_engineering007\` (base + medium prompts)

## Test plan
- [ ] CI \`dbt-fusion / Sage agent always passes\` job is green
- [ ] CI \`dbt-fusion / None agent always fails\` job stays green (these tasks should still fail there, just not be picked up at all under the duckdb variant)
- [ ] CI \`dbt / Sage agent always passes\` and \`dbt / None agent always fails\` jobs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)