### PR TITLE
Fix typos in CONTRIBUTING.md, dataset.py, and harness.py

### DIFF
--- a/ade_bench/harness.py
+++ b/ade_bench/harness.py
@@ -71,7 +71,7 @@ class Harness:
         with_profiling: bool = False,
     ):
         """
-        Runs the Terminal-Bench harness.
+        Runs the ADE-bench harness.
 
         Args:
             dataset_path: The path to the dataset.

--- a/ade_bench/utils/dataset.py
+++ b/ade_bench/utils/dataset.py
@@ -16,7 +16,7 @@ class Dataset:
         """Initialize the dataset.
 
         Args:
-            dataset_path: Path to the dataset directorygs
+            dataset_path: Path to the dataset directory
             task_ids: Optional list of specific task IDs to load
             excluded_task_ids: Optional set of task IDs to exclude
         """

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -100,7 +100,7 @@ The script automatically:
 
 ### dbt tests
 
-For an overview of how dbt tests are used to evaulate trials, see the [README](README.md#how-trials-are-evaluated). This section describes advanced ways to configure tests.
+For an overview of how dbt tests are used to evaluate trials, see the [README](README.md#how-trials-are-evaluated). This section describes advanced ways to configure tests.
 
 #### Configuring different environments
 


### PR DESCRIPTION
## Summary

- CONTRIBUTING.md: "evaulate" -> "evaluate"
- dataset.py: "directorygs" -> "directory"
- harness.py: "Terminal-Bench" -> "ADE-bench" (leftover project name in docstring)

## Test plan

- [x] Changes are cosmetic/documentation only — no behavior change
- [x] Verified patterns exist before fixing