### PR TITLE
Support CLAUDE_CODE_EFFORT and CLAUDE_CODE_OAUTH_TOKEN for the Claude Code agent

### DIFF
--- a/ade_bench/agents/installed_agents/claude_code/claude_code_agent.py
+++ b/ade_bench/agents/installed_agents/claude_code/claude_code_agent.py
@@ -28,6 +28,11 @@ class ClaudeCodeAgent(AbstractInstalledAgent):
 
     @property
     def _env(self) -> dict[str, str]:
+        # Prefer a Claude subscription OAuth token (from `claude setup-token`)
+        # when provided; otherwise fall back to an API key. strip() matches the
+        # `ab check` preflight so a whitespace-only token counts as unset here too.
+        if oauth_token := (os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or "").strip():
+            return {"CLAUDE_CODE_OAUTH_TOKEN": oauth_token}
         return {
             "ANTHROPIC_API_KEY": os.environ["ANTHROPIC_API_KEY"],
         }

--- a/ade_bench/agents/installed_agents/claude_code/claude_code_agent.py
+++ b/ade_bench/agents/installed_agents/claude_code/claude_code_agent.py
@@ -21,6 +21,11 @@ class ClaudeCodeAgent(AbstractInstalledAgent):
         self._claude_parser = ClaudeParser()
         self._log_formatter = ClaudeCodeLogFormatter()
 
+    # Optional env-var override for Claude Code's effort level, useful when
+    # comparing model/effort configurations at a matched cost budget.
+    # Mirrors OPENAI_CODEX_REASONING_EFFORT on the Codex agent.
+    _EFFORT_ENV_VAR = "CLAUDE_CODE_EFFORT"
+
     @property
     def _env(self) -> dict[str, str]:
         return {
@@ -38,6 +43,12 @@ class ClaudeCodeAgent(AbstractInstalledAgent):
 
         if self._model_name:
             command += f" --model {self._model_name}"
+
+        # Optional override of Claude Code's default effort level. Set via env
+        # var rather than a constructor kwarg so the existing harness/factory
+        # plumbing doesn't need to change to thread it through.
+        if effort := os.environ.get(self._EFFORT_ENV_VAR):
+            command += f" --effort {shlex.quote(effort)}"
 
         if self._allowed_tools:
             command += f" --allowedTools {' '.join(self._allowed_tools)}"

--- a/ade_bench/cli/ab/check.py
+++ b/ade_bench/cli/ab/check.py
@@ -137,10 +137,16 @@ def check_macro_key():
 @environmentapp.command("anthropic")
 def check_anthropic_key():
     """
-    Check ANTHROPIC_API_KEY.
+    Check ANTHROPIC_API_KEY (a CLAUDE_CODE_OAUTH_TOKEN also satisfies this).
     """
     global anthropic_available
-    if check_provider_key("ANTHROPIC_API_KEY"):
+    # A subscription OAuth token (from `claude setup-token`) is an alternative
+    # credential for the Claude Code agent; accept it before requiring a key
+    # so OAuth-only environments don't report a spurious failure.
+    if (os.getenv("CLAUDE_CODE_OAUTH_TOKEN") or "").strip():
+        add_success("CLAUDE_CODE_OAUTH_TOKEN is set.")
+        anthropic_available = True
+    elif check_provider_key("ANTHROPIC_API_KEY"):
         anthropic_available = True
 
 

--- a/tests/agents/installed_agents/test_claude_code_agent.py
+++ b/tests/agents/installed_agents/test_claude_code_agent.py
@@ -34,3 +34,32 @@ class TestEffortEnvVar:
         # The whole value is one shell-quoted token, so `rm -rf /` is part of
         # the quoted argument — never a second command.
         assert "--effort 'low; rm -rf /'" in commands[0].command
+
+
+class TestAuthEnv:
+    def test_api_key_default(self):
+        env = {"ANTHROPIC_API_KEY": "key"}
+        with patch.dict("os.environ", env, clear=True):
+            agent = ClaudeCodeAgent()
+            assert agent._env == {"ANTHROPIC_API_KEY": "key"}
+
+    def test_oauth_token_preferred(self):
+        """A subscription OAuth token takes precedence over an API key."""
+        env = {"ANTHROPIC_API_KEY": "key", "CLAUDE_CODE_OAUTH_TOKEN": "oat"}
+        with patch.dict("os.environ", env, clear=True):
+            agent = ClaudeCodeAgent()
+            assert agent._env == {"CLAUDE_CODE_OAUTH_TOKEN": "oat"}
+
+    def test_whitespace_oauth_token_treated_as_unset(self):
+        """A whitespace-only token must not shadow a valid API key."""
+        env = {"ANTHROPIC_API_KEY": "key", "CLAUDE_CODE_OAUTH_TOKEN": "  "}
+        with patch.dict("os.environ", env, clear=True):
+            agent = ClaudeCodeAgent()
+            assert agent._env == {"ANTHROPIC_API_KEY": "key"}
+
+    def test_oauth_token_without_api_key(self):
+        """OAuth-only environments must not require ANTHROPIC_API_KEY."""
+        env = {"CLAUDE_CODE_OAUTH_TOKEN": "oat"}
+        with patch.dict("os.environ", env, clear=True):
+            agent = ClaudeCodeAgent()
+            assert agent._env == {"CLAUDE_CODE_OAUTH_TOKEN": "oat"}

--- a/tests/agents/installed_agents/test_claude_code_agent.py
+++ b/tests/agents/installed_agents/test_claude_code_agent.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+from ade_bench.agents.installed_agents.claude_code.claude_code_agent import (
+    ClaudeCodeAgent,
+)
+
+
+class TestEffortEnvVar:
+    def test_no_env_var_omits_flag(self):
+        """When CLAUDE_CODE_EFFORT is unset, no --effort flag is emitted."""
+        env = {"ANTHROPIC_API_KEY": "key"}
+        with patch.dict("os.environ", env, clear=True):
+            agent = ClaudeCodeAgent()
+            commands = agent._run_agent_commands("do the thing")
+        assert "--effort" not in commands[0].command
+
+    def test_env_var_emits_effort_flag(self):
+        """When set, the value is passed via --effort <value>."""
+        env = {"ANTHROPIC_API_KEY": "key", "CLAUDE_CODE_EFFORT": "low"}
+        with patch.dict("os.environ", env, clear=True):
+            agent = ClaudeCodeAgent()
+            commands = agent._run_agent_commands("do the thing")
+        assert "--effort low" in commands[0].command
+
+    def test_env_var_value_is_shell_quoted(self):
+        """Value goes through shlex.quote so injection attempts are inert."""
+        env = {
+            "ANTHROPIC_API_KEY": "key",
+            "CLAUDE_CODE_EFFORT": "low; rm -rf /",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            agent = ClaudeCodeAgent()
+            commands = agent._run_agent_commands("do the thing")
+        # The whole value is one shell-quoted token, so `rm -rf /` is part of
+        # the quoted argument — never a second command.
+        assert "--effort 'low; rm -rf /'" in commands[0].command


### PR DESCRIPTION
## What

Two opt-in env vars for the Claude Code agent, in two separable commits:

1. **`CLAUDE_CODE_EFFORT`** — appends `--effort <value>` (`low|medium|high|xhigh|max`) to the `claude` invocation. This is the Claude Code counterpart of `OPENAI_CODEX_REASONING_EFFORT` (#149), with the same design: an env var rather than a constructor kwarg, so no harness/factory plumbing changes. Value is `shlex.quote`d. Note `--effort` requires a recent Claude Code CLI; the setup script installs latest, so this can't regress existing runs.
2. **`CLAUDE_CODE_OAUTH_TOKEN`** — when set (non-whitespace), the sandboxed CLI authenticates with a long-lived subscription OAuth token (from `claude setup-token`) instead of `ANTHROPIC_API_KEY`, letting subscription holders run benchmarks against their plan quota rather than metered API billing. The `ab check environment anthropic` preflight accepts the token too. The API key remains the default; this commit is separable if a single auth path is preferred.

Both are covered by unit tests mirroring `test_openai_codex_agent.py` (no-env-var, value emitted, shell-quoting; plus auth-precedence cases including whitespace-only tokens). Neither changes behavior when the env vars are unset.

## Why

Same motivation as #149: comparing agents/models at matched effort levels. As a working example, we used this to run all 60 ready duckdb+dbt tasks — 75 trials per arm once per-task prompt variants are included — at 1 attempt per trial (Claude Code pinned to 2.1.207), comparing `claude-fable-5 --effort low` vs `claude-opus-4-8 --effort xhigh`:

| | fable-5 / low | opus-4-8 / xhigh |
|---|---|---|
| pass@1 | 72.0% (54/75) | 74.7% (56/75) |
| discordant tasks | 2 | 4 |
| sign test | p = 0.69 (parity) | |
| avg wall-clock/trial | 85s | 181s |
| output tokens (arm) | 237k | 913k |

i.e. statistical parity on outcomes with a ~2x latency and ~4x token gap — the kind of readout this flag makes easy to produce.

## Testing

- `pytest tests/agents/installed_agents/` — 18 passed (11 existing + 7 new)
- Both env vars verified end-to-end in the benchmark runs above: the `--effort` flag is present in the recorded container commands, and OAuth auth confirmed via subscription usage accounting
- Per-trial `modelUsage` audit across all 75 fable-5 trials confirmed no cross-model fallback occurred

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

